### PR TITLE
fix(seo): tighten redirect regex

### DIFF
--- a/scripts/seo-validation/validate-templates.js
+++ b/scripts/seo-validation/validate-templates.js
@@ -83,7 +83,7 @@ class TemplateValidator {
     // Check for JavaScript redirects (exclude OAuth pages)
     if (!filePath.includes('oauth') && !filePath.includes('callback')) {
       // Purpose: only flag real redirects (writes/calls), not reads like `window.location.href`.
-      const redirectPattern = /(window\.location\.(replace|assign)\s*\(|(?:window\.)?location\.href\s*=|window\.location\.href\s*=|document\.location\s*=)/;
+      const redirectPattern = /(window\.location\.(replace|assign)\s*\(|(?:window\.)?location\.href\s*=(?![=])|document\.location\s*=(?![=]))/;
       lines.forEach((line, index) => {
         if (redirectPattern.test(line)) {
           this.addError(filePath, index + 1,


### PR DESCRIPTION
## Summary
- Tighten the template validator redirect regex so it does not match `==` / `===` comparisons.

## Test plan
- [x] `npm run seo:validate`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a validation regex that only affects lint/CI reporting, with minimal runtime impact.
> 
> **Overview**
> Tightens the template SEO validator’s JavaScript redirect detection regex in `scripts/seo-validation/validate-templates.js` to only match real `location` assignments/calls, *not* equality comparisons (`==`/`===`).
> 
> This reduces false-positive SEO validation errors when templates compare against `location.href` or `document.location` rather than performing a redirect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e380afa8a8f0c95a79527e94c4bc06a71bc4e2b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->